### PR TITLE
wrong parameter name o error payload

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -16,7 +16,7 @@
 ```javascript
 {
   "code": -1121,
-  "msg": "Invalid symbol."
+  "message": "Invalid symbol."
 }
 ```
 


### PR DESCRIPTION
The message field name on this payload was incorrect, the correct is `message` instead of `msg`