### PR TITLE
In MAX_NUM_ORDERS, rename field "limits" to "maxNumOrders"

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -1939,7 +1939,7 @@ Note that both "algo" orders and normal orders are counted for this filter.
 ```javascript
 {
   "filterType": "MAX_NUM_ORDERS",
-  "limit": 25
+  "maxNumOrders": 25
 }
 ```
 


### PR DESCRIPTION
It seems that `/api/v3/exchangeInfo` returns `maxNumOrders`, and not `limit` in the `MAX_NUM_ORDERS` symbol filter type. Example:

```javascript
{"filterType":"MAX_NUM_ORDERS","maxNumOrders":200}
```